### PR TITLE
Remove debugger statement to allow invariant to be called properly

### DIFF
--- a/src/flattenStyle.js
+++ b/src/flattenStyle.js
@@ -32,7 +32,6 @@ import type { StyleObj } from 'StyleSheetTypes';
 
 function getStyle(style) {
   if (style && typeof style === 'number') {
-    debugger;
     invariant(false, "Error when using Navigator from react-native-custom-components. Please provide a raw object to `props.sceneStyle` instead of a StyleSheet reference.");
   }
   return style;


### PR DESCRIPTION
The debugger statement here was overshadowing the invariant on the next line. If this was intentional then we can ignore this PR.