### PR TITLE
SC-1079 Babel Fix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread"
+  ],
+  "presets": [
+    "module:metro-react-native-babel-preset"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:facebookarchive/react-native-custom-components.git"
   },
   "scripts": {
-    "build": "npx babel src --out-dir dist --copy-files",
+    "build": "npx babel ./src --out-dir ./dist --copy-files",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/CustomComponents.js",
@@ -21,7 +21,10 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.11.5",
-    "@babel/core": "^7.11.5"
+    "@babel/core": "^7.11.5",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+    "metro-react-native-babel-preset": "^0.56.4"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "react-native-deprecated-custom-components",
+  "name": "@click-therapeutics-org/react-native-deprecated-custom-components",
   "version": "0.1.1",
   "description": "Deprecated custom components that originally shipped with React Native",
   "repository": {
     "type": "git",
     "url": "git@github.com:facebookarchive/react-native-custom-components.git"
   },
-  "main": "src/CustomComponents.js",
+  "scripts": {
+    "build": "npx babel src --out-dir dist --copy-files",
+    "prepublishOnly": "npm run build"
+  },
+  "main": "dist/CustomComponents.js",
   "dependencies": {
     "fbjs": "~0.8.9",
     "immutable": "~3.7.6",
@@ -14,6 +18,10 @@
     "prop-types": "^15.5.10",
     "react-timer-mixin": "^0.13.2",
     "rebound": "^0.0.13"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.11.5",
+    "@babel/core": "^7.11.5"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/src/NavigatorNavigationBar.js
+++ b/src/NavigatorNavigationBar.js
@@ -140,7 +140,7 @@ class NavigatorNavigationBar extends React.Component {
       var component = this._components[componentName].get(this.props.navState.routeStack[index]);
       var props = this._getReusableProps(componentName, index);
       if (component && interpolate[componentName](props.style, amount)) {
-        if (isNan(props.style.left)) {
+        if (isNaN(props.style.left)) {
           delete props.style.left;
         }
         props.pointerEvents = props.style.opacity === 0 ? 'none' : 'box-none';

--- a/src/NavigatorNavigationBar.js
+++ b/src/NavigatorNavigationBar.js
@@ -140,6 +140,9 @@ class NavigatorNavigationBar extends React.Component {
       var component = this._components[componentName].get(this.props.navState.routeStack[index]);
       var props = this._getReusableProps(componentName, index);
       if (component && interpolate[componentName](props.style, amount)) {
+        if (Number.isFinite(props.style.left)) {
+          delete props.style.left;
+        }
         props.pointerEvents = props.style.opacity === 0 ? 'none' : 'box-none';
         component.setNativeProps(props);
       }

--- a/src/NavigatorNavigationBar.js
+++ b/src/NavigatorNavigationBar.js
@@ -140,7 +140,7 @@ class NavigatorNavigationBar extends React.Component {
       var component = this._components[componentName].get(this.props.navState.routeStack[index]);
       var props = this._getReusableProps(componentName, index);
       if (component && interpolate[componentName](props.style, amount)) {
-        if (Number.isFinite(props.style.left)) {
+        if (isNan(props.style.left)) {
           delete props.style.left;
         }
         props.pointerEvents = props.style.opacity === 0 ? 'none' : 'box-none';


### PR DESCRIPTION
This FB react-native component is used by ct-navigation-stack. In the ct152 unit test, we will have syntax error because the react-nat0ve-custom-components under node_modules of ct-navigation-stack is not transpiler by babel. 

The reason is that ct-navigation-stack directly use github URL as source of the dependency. To solve the situation, we publish react-native-custom-components under click organization with babel performed. 